### PR TITLE
matrix transpositions in interp2lin and RmullwlskCC

### DIFF
--- a/src/interp2lin.cpp
+++ b/src/interp2lin.cpp
@@ -19,9 +19,10 @@ Eigen::VectorXd interp2lin( const Eigen::Map<Eigen::VectorXd> & xin, const Eigen
 
   // Preliminary checks
 
-  if ( nXGrid != nYGrid ){
-    Rcpp::stop("Input Y-grid does not have the same number of points as Input X-grid.");
-  } else if ( nKnownPoints != zin.size() ) {  
+  // if ( nXGrid != nYGrid ){
+    // Rcpp::stop("Input Y-grid does not have the same number of points as Input X-grid.");
+  // } else 
+  if ( nKnownPoints != zin.size() ) {  
     Rcpp::stop("Input Z-grid does not have the same number of points as the product of #Input Y-grid times #Input X-grid.");
   } else if ( nUnknownPoints != you.size() ){
     Rcpp::stop("Output Y-grid does not have the same number of points as Output X-grid.");
@@ -69,7 +70,7 @@ Eigen::VectorXd interp2lin( const Eigen::Map<Eigen::VectorXd> & xin, const Eigen
       ya(1) = *y1;
 
       const double* x1p = std::find(&xin[0], &xin[nXGrid], xa(1));
-      const double* y1p = std::find(&yin[0], &yin[nXGrid], ya(1));
+      const double* y1p = std::find(&yin[0], &yin[nYGrid], ya(1));
       const double* x0p;
       const double* y0p;
 
@@ -91,14 +92,14 @@ Eigen::VectorXd interp2lin( const Eigen::Map<Eigen::VectorXd> & xin, const Eigen
      
 
 //      const double* x1p = std::find(&xin[0], &xin[nXGrid], xa(1));
-//      const double* y1p = std::find(&yin[0], &yin[nXGrid], ya(1));
+//      const double* y1p = std::find(&yin[0], &yin[nYGrid], ya(1));
 //      const double* x0p = x1p - 1;
 //      const double* y0p = y1p - 1;
 
-      za(0) = zin( (x0p -&xin[0]) * nXGrid + (y0p -&yin[0]) );
-      za(1) = zin( (x0p -&xin[0]) * nXGrid + (y1p -&yin[0]) );
-      za(2) = zin( (x1p -&xin[0]) * nXGrid + (y0p -&yin[0]) );
-      za(3) = zin( (x1p -&xin[0]) * nXGrid + (y1p -&yin[0]) );
+      za(0) = zin( (y0p -&yin[0]) * nXGrid +  (x0p -&xin[0]));
+      za(1) = zin( (y1p -&yin[0]) * nXGrid +  (x0p -&xin[0]));
+      za(2) = zin( (y0p -&yin[0]) * nXGrid +  (x1p -&xin[0]));
+      za(3) = zin( (y1p -&yin[0]) * nXGrid +  (x1p -&xin[0]));
 
       // Column 2  
       A(0,1) = xa(0);   A(1,1) = xa(0);

--- a/tests/testthat/test_interp2lin.R
+++ b/tests/testthat/test_interp2lin.R
@@ -1,5 +1,6 @@
 # setwd('misc/') 
 # devtools::load_all()
+# devtools::load_all('../RPACE/tPACE')
 
 library(testthat)
 library(pracma)
@@ -31,6 +32,22 @@ U2 = test_that("basic pracma::interp2 (extended) example gives same output ", {
   BB = interp2lin( x, y, Z, xp, yp)
   expect_equal(sum(AA), sum(BB), tolerance = 2e-15)
 })
+
+
+U2_unequal = test_that("basic pracma::interp2 (extended) example gives same output ", {
+
+  x <- linspace(-2, 5, 10)
+  y <- linspace(-1, 4, 11)
+  mgrid <- meshgrid(x, y)
+  Z <- mgrid$X^2 + 2*mgrid$Y + 3
+  xp <- linspace(0, 3, 51)
+  yp <- linspace(0, 3, 51)
+  method <- "linear"
+  AA = interp2(x, y, Z, xp, yp, method)
+  BB = interp2lin( x, y, t(Z), xp, yp)
+  expect_equal(AA, BB, tolerance = 2e-15)
+})
+
 
 # These check out OK.
 U3 = test_that("basic pracma::interp2 (extended) example gives same output and out of sample", {
@@ -80,3 +97,32 @@ U5 = test_that("basic pracma::interp2 example gives same outputs large input gri
   system.time({BB = interp2lin( x, y, Z, xp, yp)})
   expect_equal(sum(AA), sum(BB), tolerance = 2e-15)
 })
+
+U6 = test_that("basic pracma::interp2 example gives same output on different grid size", { 
+
+  x <- linspace(-2/3, 2/3, 4)
+  y <- linspace(-1, 1, 5)
+  Z <- outer(x, y, `+`)
+  xp <- linspace(-1/2, 1/2, 4)
+  yp <- linspace(-1, 1, 4)
+  method <- "linear" 
+  AA = interp2(x, y, t(Z), xp, yp, method)
+  BB = interp2lin(x, y, Z, xp, yp)
+  expect_equal(AA, BB, tolerance = 2e-15) 
+
+})
+
+U7 = test_that("basic pracma::interp2 example gives same output on different grid size (large)", { 
+
+  x <- linspace(-1/2, 1/2, 3)
+  y <- linspace(-1, 1, 15)
+  Z <- outer(x, y, `*`)
+  xp <- linspace(-1/2, 1/2, 11)
+  yp <- linspace(-1, 1, 11)
+  method <- "linear" 
+  AA = interp2(x, y, t(Z), xp, yp, method)
+  BB = interp2lin(x, y, Z, xp, yp)
+  expect_equal(sum(AA), sum(BB), tolerance = 2e-15) 
+
+})
+

--- a/tests/testthat/test_lwls2dV2.R
+++ b/tests/testthat/test_lwls2dV2.R
@@ -33,7 +33,7 @@ if(1==1){
   
 }
 
-if(1==2){
+if(1==1){
   
   test_that('lwls2dV2 parallel works alright with a larger raw covariance',{
     
@@ -107,6 +107,7 @@ if(1==1){
     tPairs = matrix(c(1,3,4,1,2,1,1,2,3,4), ncol=2)
     
     AA = lwls2dV2(bw=c(0.5,0.5), kern ='gauss', xin=tPairs, yin=c(1,2,3,4,5), xout1=as.numeric(c(1,4)), xout2=as.numeric(c(1,4)), crosscov=TRUE);
+    AA2 = lwls2dV2(bw=c(0.5,0.5), kern ='gauss', xin=cbind(tPairs[, 2], tPairs[, 1]), yin=c(1,2,3,4,5), xout1=as.numeric(c(1,4)), xout2=as.numeric(c(1,4)), crosscov=TRUE);
     BB = lwls2dV2(bw=c(0.5,5.0), kern ='gauss', xin=tPairs, yin=c(1,2,3,4,5), xout1=as.numeric(c(1,4)), xout2=as.numeric(c(1,4)), crosscov=TRUE);
     CC = lwls2dV2(bw=c(5.0,5.0), kern ='gauss', xin=tPairs, yin=c(1,2,3,4,5), xout1=as.numeric(c(1,4)), xout2=as.numeric(c(1,4)), crosscov=TRUE);
     DD = lwls2dV2(bw=c(5.0,5.0), kern ='gauss', xin=tPairs, yin=c(1,2,3,4,5), xout1=as.numeric(c(1,4)), xout2=as.numeric(c(1,40)), crosscov=TRUE); 
@@ -118,6 +119,7 @@ if(1==1){
     # [invalid, DD]= mullwlsk_2([5.0,5.0], 'gauss', [1 3 4 1 2; 1 1 2 3 4], [1 2 3 4 5]', [1 1 1 1 1], [1  4], [1 40])
     # [invalid, ZZ]= mullwlsk_2([5.0,0.5], 'gauss', [1 3 4 1 2; 1 1 2 3 4], [1 2 3 4 5]', [1 1 1 1 1], [1  4], [1 4 4.5]); sum( ZZ(:))
     
+    expect_equal(AA, t(AA2))
     expect_equal(13.997323601735092, sum(AA), tolerance=1e-9)
     expect_equal(13.498112821557918, sum(BB), tolerance=1e-9)
     expect_equal(13.669203283501956, sum(CC), tolerance=1e-9)


### PR DESCRIPTION
fixed matrix transposition and indexing problem in `interp2lin` and `RmullwlskCC`. Now rows (first dimension) of a matrix corresponds to the first input/output dimension and columns corresponds to the second.

The change implies the output of `lwls2dV2(..., crosscov=TRUE)` would be transposed. The tests `test_interp2lin.R`
`test_lwls2dV2.R`
`test_FPCA.R`
are fine, but I didn't fix/try those for `CrCovYX`, which I highly suspect would have problems.